### PR TITLE
Small upgrade/improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv
 .nox
 _dev
 _version.py
+profiles

--- a/src/smbcrawler/args_secrets.py
+++ b/src/smbcrawler/args_secrets.py
@@ -53,6 +53,13 @@ parser.add_argument(
     help="enable recursive directory search (default: %(default)s)",
 )
 
+parser.add_argument(
+    "",
+    "--no-default",
+    default=False,
+    action="store_true",
+    help="avoid loading the default profile (default: %(default)s)",
+)
 
 def parse_args(argv=None):
     args = parser.parse_args(argv)

--- a/src/smbcrawler/args_secrets.py
+++ b/src/smbcrawler/args_secrets.py
@@ -54,7 +54,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "",
+    "-nd",
     "--no-default",
     default=False,
     action="store_true",

--- a/src/smbcrawler/clickargs.py
+++ b/src/smbcrawler/clickargs.py
@@ -156,6 +156,7 @@ def cli(debug, verbose, crawl_file):
     " specification on each line",
 )
 @click.option(
+    "-nd",
     "--no-default",
     is_flag=True,
     help="Do not load default profiles",

--- a/src/smbcrawler/clickargs.py
+++ b/src/smbcrawler/clickargs.py
@@ -155,6 +155,11 @@ def cli(debug, verbose, crawl_file):
     " can either be XML output from nmap or a target"
     " specification on each line",
 )
+@click.option(
+    "--no-default",
+    is_flag=True,
+    help="Do not load default profiles",
+)
 @click.argument(
     "target",
     nargs=-1,
@@ -178,6 +183,7 @@ def crawl(
     dry_run,
     input,
     target,
+    no_default,  # Add this parameter
 ):
     """Start crawling shares for secrets
 
@@ -198,7 +204,10 @@ def crawl(
         log_level = "DEBUG"
     init_logger(log_level=log_level)
     profile_collection = collect_profiles(
-        extra_profile_directory, extra_profile_file, update_profile
+        extra_dirs=extra_profile_directory,
+        extra_files=extra_profile_file,
+        update_queries=update_profile,
+        load_default=not no_default,  # Pass the parameter
     )
 
     logger = logging.getLogger(__name__)

--- a/src/smbcrawler/io.py
+++ b/src/smbcrawler/io.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 def parse_targets(s):
     # TODO ipv6
-    if re.match(r"^[a-zA-Z0-9-.]+(:[0-9]{1,5})?$", s) or re.match(
+    if re.match(r"^[a-zA-Z0-9-_.]+(:[0-9]{1,5})?$", s) or re.match(
         r"^([0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$", s
     ):
         # single ip or host name

--- a/src/smbcrawler/profiles.py
+++ b/src/smbcrawler/profiles.py
@@ -137,8 +137,9 @@ def collect_profiles(
         files.append(SCRIPT_PATH / "default_profile.yml")
 
     for d in dirs:
-        for f in glob.glob(str(pathlib.Path(d) / "*.yml")):
-            files.append(pathlib.Path(d) / f)
+        for pattern in ["**/*.yml", "**/*.yaml"]:
+            for f in pathlib.Path(d).rglob(pattern):
+                files.append(f)
 
     files.extend(map(pathlib.Path, extra_files))
 

--- a/src/smbcrawler/profiles.py
+++ b/src/smbcrawler/profiles.py
@@ -123,18 +123,16 @@ def collect_profiles(
     load_default: bool = True,  # Add this parameter
 ) -> ProfileCollection:
     """Search directories for profile files"""
-    dirs = [
-        xdg.BaseDirectory.save_config_path("smbcrawler"),
-        os.getcwd(),
-    ]
-
-    for d in extra_dirs:
-        dirs.append(d)
-
-    files = []
+    dirs = []
+    files = []  # Initialize the files list
 
     if load_default:  # Conditionally add the default profile
         files.append(SCRIPT_PATH / "default_profile.yml")
+
+    if extra_dirs:
+        dirs.extend(extra_dirs)
+    else:
+        dirs.append(xdg.BaseDirectory.save_config_path("smbcrawler"))
 
     for d in dirs:
         for pattern in ["**/*.yml", "**/*.yaml"]:

--- a/src/smbcrawler/profiles.py
+++ b/src/smbcrawler/profiles.py
@@ -120,6 +120,7 @@ def collect_profiles(
     extra_dirs: list[str] = [],
     extra_files: list[str] = [],
     update_queries: list[str] = [],
+    load_default: bool = True,  # Add this parameter
 ) -> ProfileCollection:
     """Search directories for profile files"""
     dirs = [
@@ -130,9 +131,10 @@ def collect_profiles(
     for d in extra_dirs:
         dirs.append(d)
 
-    files = [
-        SCRIPT_PATH / "default_profile.yml",
-    ]
+    files = []
+
+    if load_default:  # Conditionally add the default profile
+        files.append(SCRIPT_PATH / "default_profile.yml")
 
     for d in dirs:
         for f in glob.glob(str(pathlib.Path(d) / "*.yml")):


### PR DESCRIPTION
### Bug Fixes
- Fixed regex pattern in `parse_targets` function to correctly handle hostnames with underscores.

### Improvements:
- Added option `-nd` `--no-default` to disable default template (aka profile) to be loaded
- Now `yml` and `yaml` both file extensions can be used
- Changed recursive loading for the `--extra-profile-directory` (`-Y`) to follow following directory structure 
```
profiles
├── directories
│   ├── boring.yaml
│   └── intresting.yaml
├── files
│   ├── configs.yaml
│   ├── databases.yaml
│   ├── generic.yaml
│   ├── keys.yaml
│   ├── passwords.yaml
│   └── scripts.yaml
├── secrets
│   └── secrets.yaml
└── shares
    ├── boring.yaml
    └── intresting.yaml
```

> The profiles folder has added to gitignore as was not very open to share the templates however based on name shown above - someone can write their own smaller chunks 🙂🙂

