### PR TITLE
Fix database queries for usage in HTML report

### DIFF
--- a/src/smbcrawler/queries.py
+++ b/src/smbcrawler/queries.py
@@ -122,12 +122,15 @@ WITH
     )
 
 -- Final selection from the recursive CTE
-SELECT
-    secret, line, line_number, target_name, share_name, path, content_hash
-FROM
-    FullPath
-ORDER BY
-    secret, target_name, share_name, path
+SELECT *
+FROM (
+    SELECT
+        secret, line, line_number, target_name, share_name, path, content_hash
+    FROM
+        FullPath
+    ORDER BY
+        secret, target_name, share_name, path
+)
 """,
     serialized_paths="""
 WITH RECURSIVE FullPath AS (
@@ -166,12 +169,15 @@ WITH RECURSIVE FullPath AS (
         FullPath AS fp ON p.parent_id = fp.id
 )
 -- Final selection from the recursive CTE
-SELECT DISTINCT
-    target_name, share_name, full_path, size, high_value
-FROM
-    FullPath
-ORDER BY
-    target_name, share_name, full_path
+SELECT *
+FROM (
+    SELECT DISTINCT
+        target_name, share_name, full_path, size, high_value
+    FROM
+        FullPath
+    ORDER BY
+        target_name, share_name, full_path
+)
 """,
     shares_listable_root="SELECT * FROM share WHERE read_level > 0 ORDER BY target_id, name",
     shares_listable_root_as_guest='SELECT * FROM share WHERE read_level > 0 AND guest_access = "1" ORDER BY target_id, name',


### PR DESCRIPTION
The "paths" and "secrets" tabs of the HTML export currently throw the following error:
<img width="1112" height="310" alt="smbcrawler-error" src="https://github.com/user-attachments/assets/65dfc9b8-ce66-45e5-8b67-9494a9b24d80" />

This is due to the query definition in line 65 in the file [common.js](https://github.com/SySS-Research/smbcrawler/blob/main/src/smbcrawler/assets/static/common.js). There the "${select}" part already contains a "ORDER BY" instruction which is followed by a "WHERE". This leads to a `[Grid.js] [ERROR]: Error: near "WHERE": syntax error`  error when trying to execute the query in the browser.

I've encapsulated the `SELECT` parts of the queries in another `SELECT * FROM (` instruction. This ensures the function in other parts of the code (e.g. in [reporting.py](https://github.com/SySS-Research/smbcrawler/blob/main/src/smbcrawler/reporting.py)) while still being able to append a `WHERE` clause.

Thank you for this awesome tool!