### PR TITLE
Add support for Kerberos authentication

### DIFF
--- a/src/smbcrawler/app.py
+++ b/src/smbcrawler/app.py
@@ -17,14 +17,17 @@ log = logging.getLogger(__name__)
 
 
 class Login(object):
-    def __init__(self, username, domain, password="", hash=""):
+    def __init__(self, username, domain, password="", nthash="", aeskey="", kdchost=None, use_kerberos=False):
         self.username = username
         self.domain = domain
         self.password = password
-        self.hash = hash
+        self.nthash = nthash
+        self.aeskey = aeskey
+        self.kdchost = kdchost
+        self.use_kerberos = use_kerberos
 
     def __str__(self):
-        return f"{self.domain}/{self.username}:{self.password or self.hash}"
+        return f"{self.domain}/{self.username}:{self.password or self.nthash or self.aeskey}"
 
 
 class CrawlerApp(object):


### PR DESCRIPTION
This adds new corresponding cli parameters and passes them through to impacket. With that, the following different authentication methods work (tested in a lab):

```
smbcrawler crawl -D -1 $DC    -u $USR -d $DOMAIN -p "$PASS"                      # NTLM with username/password
smbcrawler crawl -D -1 $DC    -u $USR -d $DOMAIN --nthash "$NTHASH"              # NTLM with nthash

smbcrawler crawl -D -1 $DC -k -u $USR -d $DOMAIN -p "$PASS"         --dc-ip $DC  # Kerberos with username/password
smbcrawler crawl -D -1 $DC -k -u $USR -d $DOMAIN --nthash "$NTHASH" --dc-ip $DC  # Kerberos with nthash
smbcrawler crawl -D -1 $DC -k -u $USR -d $DOMAIN --aeskey "$AESKEY" --dc-ip $DC  # Kerberos with aeskey
KRB5CCNAME=tgt.ccache smbcrawler crawl -D -1 $DC -k --use-ccache    --dc-ip $DC  # Kerberos with ccache
```